### PR TITLE
Add separate cache for

### DIFF
--- a/app/src/regexp-utils.ts
+++ b/app/src/regexp-utils.ts
@@ -167,7 +167,7 @@ const RegExpUtils = {
       // optionally followed by: a query string and/or a #location
       // (last character must not be puncation, hence two groups)
       "(?:(\\?[\\-\\+=&;%@\\.\\w_\\#]*[\\#\\-\\+=&;%@\\w_\\/]+)?#?(?:['\\$\\&\\(\\)\\*\\+,;=\\.\\!\\/\\\\\\w%-?]*[\\/\\\\\\w]+)?)?",
-      ')?',
+      ')?+',
       ')',
     ];
     if (matchStartOfString) {


### PR DESCRIPTION
…h and then “return” #

This change makes this part of the regexp “greedy and posessive”, meaning that if the regexp reaches the `$` end-of-string qualifier and it’s not the end of the string, it can’t go back and try to change the way it allocated characters to the regexp to make it work (infinitely.)